### PR TITLE
Create a shallow copy of idleConnections.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -436,7 +436,7 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
   public end(): void {
     this.isEnding = true;
 
-    for (const idleConnection of this.idleConnections) {
+    for (const idleConnection of Array.from(this.idleConnections)) {
       this._removeConnection(idleConnection);
     }
   }


### PR DESCRIPTION
When calling `end()` with multiple idleConnections the `for of` operator is used with slicing the same array. 
This causes issues with the index and jumps over some.

Proof: https://www.typescriptlang.org/play/?ssl=11&ssc=30&pln=1&pc=1#code/MYewdgzgLgBAlgEwDYFMDC4wuFO4IwC8MA2gHQUCCATtQIYCeAFAIwAMAlGQNYoMRMOAXTIBbOgAcmcIgD4YAbxjUUUAK7UwimKDBYceMAEkEALngwAvlY4BuALAAoJ7oghUZJCADm05OkxsXHw7JycAMxBqGCZXWF0tEHD4fww9IMMIDkUnGDydfFg4MAQUAA8iFNQ0-WDIMmLSsoB5cNjMUOdHfKqA9IN8MggJJDhgFGkS8oAaGBZOyzDHV3cUTx8-asCByDsgA

```
const idleConnections = [...Array(10).keys()].map(i => { return { connectionId: i } });

console.log(idleConnections);

for (const conn of idleConnections) {
    const index = idleConnections.indexOf(conn);

    idleConnections.splice(index, 1);
}

console.log(idleConnections);
```

yields

```
[LOG]: [{
  "connectionId": 0
}, {
  "connectionId": 1
}, {
  "connectionId": 2
}, {
  "connectionId": 3
}, {
  "connectionId": 4
}, {
  "connectionId": 5
}, {
  "connectionId": 6
}, {
  "connectionId": 7
}, {
  "connectionId": 8
}, {
  "connectionId": 9
}] 
[LOG]: [{
  "connectionId": 1
}, {
  "connectionId": 3
}, {
  "connectionId": 5
}, {
  "connectionId": 7
}, {
  "connectionId": 9
}] 

```

This fixes #54