### PR TITLE
Solve discrepancy between docs and code, removing async in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const pool = new Pool({
   connectionString: 'postgres://username:pwd@127.0.0.1/db_name',
 });
 
-await pool.end();
+pool.end();
 ```
 
 ### Explicit connection details instead of a connection string


### PR DESCRIPTION
There is a discrepancy between the docs about whether `Pool.end()` is `async` or not.

The docs say: YES. 
https://github.com/postgres-pool/postgres-pool/blame/d2b1995d91d4a20fdfea5ff0772fb9095c30badd/README.md#L73

The code says: NO. 
https://github.com/postgres-pool/postgres-pool/blob/7c2397449c8bc60369ae56885712fc537f493004/src/index.ts#L436

I fixed the docs to match the code. 

[Or make `end()` actually `async`! 😉 ](https://github.com/postgres-pool/postgres-pool/pull/57)