### PR TITLE
Solve discrepancy between docs and code, making end async.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ export interface PoolOptionsImplicit {
 export type PoolClient = Client & {
   uniqueId: string;
   idleTimeoutTimer?: NodeJS.Timer;
-  release: (removeConnection?: boolean) => void;
+  release: (removeConnection?: boolean) => Promise<void>;
   errorHandler: (err: Error) => void;
 };
 
@@ -465,7 +465,7 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
         throw ex;
       }
     } finally {
-      connection.release(removeConnection);
+      await connection.release(removeConnection);
     }
 
     // If we get here, that means that the query was attempted with a read-only connection.

--- a/src/index.ts
+++ b/src/index.ts
@@ -556,8 +556,8 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
 
     client.errorHandler = (err: Error): void => {
       // fire and forget, we will always emit the error.
-      // eslint-disable-next-line promise/catch-or-return
-      this._removeConnection(client).finally(() => this.emit('error', err, client));
+      // eslint-disable-next-line no-void
+      void this._removeConnection(client).finally(() => this.emit('error', err, client));
     };
 
     client.on('error', client.errorHandler);

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,6 +554,10 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
       }
     };
 
+    // we assign an async promise to a void
+    // because we don't want to enforce a promise signature
+    // on errorHandler
+    // also, EventEmitter.on("error") doesn't support () => Promise<void> (see the on("error"))
     client.errorHandler = async (err: Error): Promise<void> => {
       await this._removeConnection(client);
       this.emit('error', err, client);


### PR DESCRIPTION
There is a discrepancy between the docs about whether `Pool.end()` is `async` or not.

The docs say: YES. 
https://github.com/postgres-pool/postgres-pool/blame/d2b1995d91d4a20fdfea5ff0772fb9095c30badd/README.md#L73

The code says: NO. 
https://github.com/postgres-pool/postgres-pool/blob/7c2397449c8bc60369ae56885712fc537f493004/src/index.ts#L436

I took a stab at making `end()` async.

It doesn't CHANGE anything in the code except for that we now explicitly await to `end` a `poolClient`.

Since we use this library quite extensively in our private code I took the liberty of compiling it and using it in our test-suite, and apart from having to add `await` in front of `pool.end()` all tests pass identically. 

The advantage now is that I can call `await pool.end()` and be sure that once that's done all connections are closed, something which we couldn't before, as we didn't await the `client.end()`.

[Or remove the `await` from the docs 😉 ](https://github.com/postgres-pool/postgres-pool/pull/56)