### PR TITLE
fix: allow object query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,7 +405,7 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
     }
 
     if (_.isEmpty(values) || !values) {
-      return this._query(text, []);
+      return this._query(text);
     }
 
     // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec


### PR DESCRIPTION
the brackets are not needed as far as I can tell, and they prevent you from giving the query in the form of an object, example:
```
pg.query(
  {
    text: "select * from table where id=$1",
    values: [23],
    rowMode: 'array',
  }
)
```
as documented in https://node-postgres.com/features/queries
with this simple fix, this style of invocation works fine