### PR TITLE
fix: Add 'ECONNREFUSED' to retry connection error codes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export class Pool extends (EventEmitter as new () => PoolEmitter) {
       connectionTimeoutMillis: 5000,
       retryConnectionMaxRetries: 5,
       retryConnectionWaitMillis: 100,
-      retryConnectionErrorCodes: ['ENOTFOUND', 'EAI_AGAIN', 'ERR_PG_CONNECT_TIMEOUT', 'timeout expired'],
+      retryConnectionErrorCodes: ['ECONNREFUSED', 'ENOTFOUND', 'EAI_AGAIN', 'ERR_PG_CONNECT_TIMEOUT', 'timeout expired'],
       reconnectOnDatabaseIsStartingError: true,
       waitForDatabaseStartupMillis: 0,
       databaseStartupTimeoutMillis: 90000,


### PR DESCRIPTION
On k8s, if the database pod changes its IP address due to being restarted or evicted, connections start failing with ECONNREFUSED because the database is not there anymore, but this error code was not among the ones that trigger a connection retry by default.